### PR TITLE
chore(dockerignore): remove unnecessary entries and fix formatting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
-﻿**/.dockerignore
+**/.dockerignore
 **/.env
-**/.git
-**/.gitignore
 **/.project
 **/.settings
 **/.toolstarget


### PR DESCRIPTION
Remove .git and .gitignore from .dockerignore as they are not needed. Fix formatting by removing BOM character at the start of the file.